### PR TITLE
Add feature history

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -444,16 +444,17 @@ class Rollout
     !active?(feature, user)
   end
 
-  def activate_percentage(feature, percentage)
+  def activate_percentage(feature, percentage, uid=nil, comment=nil)
     with_feature(feature) do |f|
       f.percentage = percentage
+      write_history(f, :activate_percentage, uid, comment)
     end
-    # TODO -- add percentage history!
   end
 
-  def deactivate_percentage(feature)
+  def deactivate_percentage(feature, uid=nil, comment=nil)
     with_feature(feature) do |f|
       f.percentage = 0
+      write_history(f, :deactivate_percentage, uid, comment)
     end
   end
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -415,21 +415,21 @@ class Rollout
     end
   end
 
-  def activate_users(feature, users, uid=nil, comment=nil)
+  def activate_users(feature, users, uid = nil, comment =  nil)
     with_feature(feature) do |f|
       users.each { |user| f.add_user(user) }
       write_history(f, :activate_users, uid, comment)
     end
   end
 
-  def deactivate_users(feature, users, uid=nil, comment=nil)
+  def deactivate_users(feature, users, uid  = nil, comment = nil)
     with_feature(feature) do |f|
       users.each { |user| f.remove_user(user) }
       write_history(f, :deactivate_users, uid, comment)
     end
   end
 
-  def set_users(feature, users, uid=nil, comment=nil)
+  def set_users(feature, users, uid = nil, comment = nil)
     with_feature(feature) do |f|
       f.users = []
       users.each { |user| f.add_user(user) }
@@ -455,14 +455,14 @@ class Rollout
     !active?(feature, user)
   end
 
-  def activate_percentage(feature, percentage, uid=nil, comment=nil)
+  def activate_percentage(feature, percentage, uid = nil, comment = nil)
     with_feature(feature) do |f|
       f.percentage = percentage
       write_history(f, :activate_percentage, uid, comment)
     end
   end
 
-  def deactivate_percentage(feature, uid=nil, comment=nil)
+  def deactivate_percentage(feature, uid = nil, comment = nil)
     with_feature(feature) do |f|
       f.percentage = 0
       write_history(f, :deactivate_percentage, uid, comment)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -529,7 +529,7 @@ class Rollout
   end
 
   def get_full_history(feature, max = -1)
-    history = @storage.lrange(history_key(feature), 0, -1) || []
+    history = @storage.lrange(history_key(feature), 0, max) || []
     history.map do |entry|
       parse_history_record(entry)
     end

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -572,7 +572,7 @@ class Rollout
   end
 
   def history_key(name)
-    "feature_history:#{name}"
+    "feature:#{name}:history"
   end
 
   def create_history_record(feature, op, uid, comment)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -523,7 +523,7 @@ class Rollout
   end
 
   def get_most_recent_history(feature)
-    entry = Storage.store.lindex(history_key(feature), 0)
+    entry = @storage.lindex(history_key(feature), 0)
     return nil if entry.nil?
     parse_history_record(entry)
   end
@@ -537,7 +537,7 @@ class Rollout
 
   def write_history(feature, op, uid, comment)
     if uid || comment
-      Storage.store.lpush(
+      @storage.lpush(
         history_key(feature.name),
         create_history_record(feature, op, uid, comment)
       )

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -366,6 +366,14 @@ class Rollout
     end
   end
 
+  def add_history(feature, op, uid, comment)
+    raise ArgumentError, 'op cannot contain space characters' if op.to_s.include? ' '
+
+    with_feature(feature) do |f|
+    write_history(f, op, uid, comment)
+    end
+  end
+
   def delete(feature)
     features = (@storage.get(features_key) || "").split(",")
     features.delete(feature.to_s)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -415,22 +415,25 @@ class Rollout
     end
   end
 
-  def activate_users(feature, users)
+  def activate_users(feature, users, uid=nil, comment=nil)
     with_feature(feature) do |f|
       users.each { |user| f.add_user(user) }
+      write_history(f, :activate_users, uid, comment)
     end
   end
 
-  def deactivate_users(feature, users)
+  def deactivate_users(feature, users, uid=nil, comment=nil)
     with_feature(feature) do |f|
       users.each { |user| f.remove_user(user) }
+      write_history(f, :deactivate_users, uid, comment)
     end
   end
 
-  def set_users(feature, users)
+  def set_users(feature, users, uid=nil, comment=nil)
     with_feature(feature) do |f|
       f.users = []
       users.each { |user| f.add_user(user) }
+      write_history(f, :set_users, uid, comment)
     end
   end
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -529,7 +529,7 @@ class Rollout
   end
 
   def get_full_history(feature, max = -1)
-    history = @storage.lrange(history_key(feature), 0, max) || []
+    history = @storage.lrange(history_key(feature), 0, max > 0 ? max - 1 : max) || []
     history.map do |entry|
       parse_history_record(entry)
     end

--- a/lib/rollout/version.rb
+++ b/lib/rollout/version.rb
@@ -1,3 +1,3 @@
 class Rollout
-  VERSION = "2.4.3-BARK-1"
+  VERSION = "2.4.3-BARK-2"
 end

--- a/rollout.gemspec
+++ b/rollout.gemspec
@@ -5,8 +5,8 @@ require "rollout/version"
 Gem::Specification.new do |s|
   s.name        = "rollout"
   s.version     = Rollout::VERSION
-  s.authors     = ["James Golick", "Gary Burns"]
-  s.email       = ["jamesgolick@gmail.com", "gary@barkbox.com"]
+  s.authors     = ["James Golick", "Gary Burns", "Keith Corwin"]
+  s.email       = ["jamesgolick@gmail.com", "gary@barkbox.com", "keith@barkbox.com"]
   s.description = "Feature flippers with redis."
   s.summary     = "Feature flippers with redis."
   s.homepage    = "https://github.com/FetLife/rollout"

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -680,9 +680,9 @@ RSpec.describe "Rollout" do
 
       describe 'Write and read history' do
         it 'should write history when you do a thing' do
-          @rollout.activate(:sup, uid=3, comment='some words')
+          @rollout.activate(:dope_feature_name, uid=3, comment='some words')
 
-          history = @rollout.get_most_recent_history(:sup)
+          history = @rollout.get_most_recent_history(:dope_feature_name)
 
           expect(history[:op]).to eq :update
           expect(history[:uid]).to eq 3
@@ -690,9 +690,9 @@ RSpec.describe "Rollout" do
           expect(history[:new_value]).to eq '100'
           expect(history[:comment]).to eq 'some words'
 
-          @rollout.deactivate(:sup, uid=4, comment='bye bye!')
+          @rollout.deactivate(:dope_feature_name, uid=4, comment='bye bye!')
 
-          history = @rollout.get_most_recent_history(:sup)
+          history = @rollout.get_most_recent_history(:dope_feature_name)
 
           expect(history[:op]).to eq :clear
           expect(history[:uid]).to eq 4
@@ -700,7 +700,7 @@ RSpec.describe "Rollout" do
           expect(history[:new_value]).to eq '0'
           expect(history[:comment]).to eq 'bye bye!'
 
-          history = @rollout.get_full_history(:sup)
+          history = @rollout.get_full_history(:dope_feature_name)
 
           expect(history[0][:op]).to eq :clear
           expect(history[0][:uid]).to eq 4
@@ -712,6 +712,20 @@ RSpec.describe "Rollout" do
           expect(history[1][:timestamp].to_i).to be_within(10).of(Time.now.to_i)
           expect(history[1][:new_value]).to eq '100'
           expect(history[1][:comment]).to eq 'some words'
+        end
+
+        it 'should record percentage changes in history' do
+          @rollout.activate_percentage(:dope_feature_name, 33, uid=3, comment='thirty-three!')
+          @rollout.deactivate_percentage(:dope_feature_name, uid=4, comment='now off')
+          @rollout.activate_percentage(:dope_feature_name, 66, uid=5, comment='sixty-six!')
+          @rollout.activate(:dope_feature_name, uid=6, comment='lets go for it')
+
+          history = @rollout.get_full_history(:dope_feature_name)
+
+          expect(history[0]).to include(op: :update, uid: 6, new_value: '100', comment: 'lets go for it')
+          expect(history[1]).to include(op: :activate_percentage, uid: 5, new_value: '66', comment: 'sixty-six!')
+          expect(history[2]).to include(op: :deactivate_percentage, uid: 4, new_value: '0', comment: 'now off')
+          expect(history[3]).to include(op: :activate_percentage, uid: 3, new_value: '33', comment: 'thirty-three!')
         end
       end
     end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -751,7 +751,6 @@ RSpec.describe "Rollout" do
         @rollout.deactivate_users(:dope_feature_name, [2, 4], uid=1)
         @rollout.set_users(:dope_feature_name, [5, 6], uid=1)
 
-
         history = @rollout.get_full_history(:dope_feature_name)
         expect(history[0]).to include(op: :set_users)
         expect(history[1]).to include(op: :deactivate_users)

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -744,6 +744,19 @@ RSpec.describe "Rollout" do
           @rollout.add_history(:dope_feature_name, 'with a space', 1, 'blah blah')
         }.to raise_error(ArgumentError)
       end
+
+      it 'records changes to activating and deactivating users' do
+        @rollout.activate(:dope_feature_name, uid=1, comment='yo')
+        @rollout.activate_users(:dope_feature_name, [1, 2, 3, 4], uid=1, comment='lol')
+        @rollout.deactivate_users(:dope_feature_name, [2, 4], uid=1)
+        @rollout.set_users(:dope_feature_name, [5, 6], uid=1)
+
+
+        history = @rollout.get_full_history(:dope_feature_name)
+        expect(history[0]).to include(op: :set_users)
+        expect(history[1]).to include(op: :deactivate_users)
+        expect(history[2]).to include(op: :activate_users)
+      end
     end
 
     describe "Rollout::Feature" do

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -730,6 +730,20 @@ RSpec.describe "Rollout" do
           expect(history[3]).to include(op: :activate_percentage, uid: 3, new_value: '33', comment: 'thirty-three!')
         end
       end
+
+      it 'can handle single freeform history additions' do
+        @rollout.activate(:dope_feature_name, uid=1, comment='yo')
+        @rollout.add_history(:dope_feature_name, 'an_operation', 1, 'added some stuff')
+
+        history = @rollout.get_full_history(:dope_feature_name)
+
+        expect(history[0]).to include(op: :an_operation, uid: 1, comment: 'added some stuff')
+        expect(history[1]).to include(op: :update, uid: 1, new_value: '100', comment: 'yo')
+
+        expect {
+          @rollout.add_history(:dope_feature_name, 'with a space', 1, 'blah blah')
+        }.to raise_error(ArgumentError)
+      end
     end
 
     describe "Rollout::Feature" do

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -677,6 +677,43 @@ RSpec.describe "Rollout" do
           expect(@rollout.exists?(:chat)).to be false
         end
       end
+
+      describe 'Write and read history' do
+        it 'should write history when you do a thing' do
+          @rollout.activate(:sup, uid=3, comment='some words')
+
+          history = @rollout.get_most_recent_history(:sup)
+
+          expect(history[:op]).to eq :update
+          expect(history[:uid]).to eq 3
+          expect(history[:timestamp].to_i).to be_within(10).of(Time.now.to_i)
+          expect(history[:new_value]).to eq '100'
+          expect(history[:comment]).to eq 'some words'
+
+          @rollout.deactivate(:sup, uid=4, comment='bye bye!')
+
+          history = @rollout.get_most_recent_history(:sup)
+
+          expect(history[:op]).to eq :clear
+          expect(history[:uid]).to eq 4
+          expect(history[:timestamp].to_i).to be_within(10).of(Time.now.to_i)
+          expect(history[:new_value]).to eq '0'
+          expect(history[:comment]).to eq 'bye bye!'
+
+          history = @rollout.get_full_history(:sup)
+
+          expect(history[0][:op]).to eq :clear
+          expect(history[0][:uid]).to eq 4
+          expect(history[0][:timestamp].to_i).to be_within(10).of(Time.now.to_i)
+          expect(history[0][:new_value]).to eq '0'
+          expect(history[0][:comment]).to eq 'bye bye!'
+          expect(history[1][:op]).to eq :update
+          expect(history[1][:uid]).to eq 3
+          expect(history[1][:timestamp].to_i).to be_within(10).of(Time.now.to_i)
+          expect(history[1][:new_value]).to eq '100'
+          expect(history[1][:comment]).to eq 'some words'
+        end
+      end
     end
 
     describe "Rollout::Feature" do

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -712,6 +712,8 @@ RSpec.describe "Rollout" do
           expect(history[1][:timestamp].to_i).to be_within(10).of(Time.now.to_i)
           expect(history[1][:new_value]).to eq '100'
           expect(history[1][:comment]).to eq 'some words'
+
+          expect(@rollout.get_full_history(:dope_feature_name, 2).length).to eq 2
         end
 
         it 'should record percentage changes in history' do


### PR DESCRIPTION
Updated a bunch of methods to take optional uid and comment arguments. When one or both are provided, we write to a new list structure, stored in `feature:<name>:history` that uses a space-delimited format (which is weird, yes - but wanted to keep things human readable within redis, and json adds lots of bloat).

Added specs, feel pretty good about this, but obvs the major concern is this breaking existing functionality.